### PR TITLE
Fixed the pie chart, table header name and table value issue

### DIFF
--- a/src/components/Assets.tsx/AssetSection1.tsx
+++ b/src/components/Assets.tsx/AssetSection1.tsx
@@ -14,13 +14,16 @@ type propsType = {
   neutronAssets: assetType[];
   strideAssets: assetType[];
   cosmosAssets: assetType[];
+  areAllAssetsLoaded: boolean;
 };
+
 
 const AssetSection1 = ({
   neutronAssets,
   strideAssets,
   cosmosAssets,
   allAssets,
+  areAllAssetsLoaded
 }: propsType) => {
   const getTotalValue = (assets: assetType[]) => {
     return assets.reduce(
@@ -67,17 +70,17 @@ const AssetSection1 = ({
     let graphData = option.map((item) => {
       return {
         label: item.name.label,
-        amount: item.total_supply,
+        total_supply: item.total_supply,
       };
     });
 
-    graphData.sort((a, b) => b.amount - a.amount);
+    graphData.sort((a, b) => b.total_supply - a.total_supply);
 
     let topData = graphData.slice(0, numberOfDataInDoughnut - 1);
 
     let sumOthers = graphData
       .slice(numberOfDataInDoughnut - 1)
-      .reduce((sum, item) => sum + item.amount, 0);
+      .reduce((sum, item) => sum + item.total_supply, 0);
 
 
     let result = [...topData];
@@ -85,7 +88,7 @@ const AssetSection1 = ({
     if (sumOthers !== 0) {
       let others = {
         label: "Others",
-        amount: sumOthers,
+        total_supply: sumOthers,
       };
 
       result = [...result, others];
@@ -156,7 +159,7 @@ const AssetSection1 = ({
               }`}
             subtitle="Stay up to date"
           >
-            {option.length ? (
+            {((selectedOption!=="all network" && option.length) || (selectedOption==="all network" && areAllAssetsLoaded)) ? (
               <CustomTable
                 keys={Object.keys(option[0])}
                 data={option}
@@ -197,7 +200,7 @@ const AssetSection1 = ({
               }`}
             subtitle="A gathering place to address the topics shaping the ATOM Ecosystem"
           >
-            {finalData.length > 0 ? (
+            {((finalData.length > 0 && selectedOption!=="all network") || (selectedOption==="all network" && areAllAssetsLoaded)) ? (
               <Flex
                 flexDirection={"column"}
                 maxHeight={"400px"}
@@ -209,7 +212,7 @@ const AssetSection1 = ({
                 {/* <DoughnutChart data={finalData} /> */}
                 <DoughnutGraph
                   doughnutData={finalData}
-                  dataKey="amount"
+                  dataKey="total_supply"
                   labelKey="label"
                   colors={[
                     "#fc7779",

--- a/src/components/Assets.tsx/AssetSection1.tsx
+++ b/src/components/Assets.tsx/AssetSection1.tsx
@@ -48,6 +48,7 @@ const AssetSection1 = ({
         combinedData[label] = { ...item };
       } else {
         combinedData[label].total_supply += item.total_supply;
+        combinedData[label].value += item.value;
       }
     });
 
@@ -71,6 +72,7 @@ const AssetSection1 = ({
       return {
         label: item.name.label,
         total_supply: item.total_supply,
+        value: item.value
       };
     });
 
@@ -78,17 +80,22 @@ const AssetSection1 = ({
 
     let topData = graphData.slice(0, numberOfDataInDoughnut - 1);
 
-    let sumOthers = graphData
+    let sumOthersTotalSupply = graphData
       .slice(numberOfDataInDoughnut - 1)
       .reduce((sum, item) => sum + item.total_supply, 0);
+
+    let sumOthersTotalValue = graphData
+    .slice(numberOfDataInDoughnut - 1)
+    .reduce((sum, item) => sum + item.value, 0);
 
 
     let result = [...topData];
 
-    if (sumOthers !== 0) {
+    if (sumOthersTotalSupply !== 0) {
       let others = {
         label: "Others",
-        total_supply: sumOthers,
+        total_supply: sumOthersTotalSupply,
+        value: sumOthersTotalValue
       };
 
       result = [...result, others];
@@ -212,7 +219,7 @@ const AssetSection1 = ({
                 {/* <DoughnutChart data={finalData} /> */}
                 <DoughnutGraph
                   doughnutData={finalData}
-                  dataKey="total_supply"
+                  dataKey="value"
                   labelKey="label"
                   colors={[
                     "#fc7779",

--- a/src/components/Assets.tsx/AssetSection1.tsx
+++ b/src/components/Assets.tsx/AssetSection1.tsx
@@ -79,12 +79,17 @@ const AssetSection1 = ({
       .slice(numberOfDataInDoughnut - 1)
       .reduce((sum, item) => sum + item.amount, 0);
 
-    let others = {
-      label: "Others",
-      amount: sumOthers,
-    };
 
-    let result = [...topData, others];
+    let result = [...topData];
+
+    if (sumOthers !== 0) {
+      let others = {
+        label: "Others",
+        amount: sumOthers,
+      };
+
+      result = [...result, others];
+    }
 
     setFinalData(result);
   }, [option]);
@@ -141,15 +146,14 @@ const AssetSection1 = ({
         >
           <Section
             height="100%"
-            heading={`Assets on ${
-              option === cosmosAssets
+            heading={`Assets on ${option === cosmosAssets
                 ? " Cosmos Hub"
                 : option === neutronAssets
-                ? " Neutron"
-                : option === combinedAllAssets
-                ? "All Network"
-                : " Stride"
-            }`}
+                  ? " Neutron"
+                  : option === combinedAllAssets
+                    ? "All Network"
+                    : " Stride"
+              }`}
             subtitle="Stay up to date"
           >
             {option.length ? (
@@ -183,15 +187,14 @@ const AssetSection1 = ({
           <Section
             height="100%"
             gap="60px"
-            heading={`Total supply on ${
-              option === cosmosAssets
+            heading={`Total supply on ${option === cosmosAssets
                 ? " Cosmos Hub"
                 : option === neutronAssets
-                ? " Neutron"
-                : option === combinedAllAssets
-                ? " All Network"
-                : " Stride"
-            }`}
+                  ? " Neutron"
+                  : option === combinedAllAssets
+                    ? " All Network"
+                    : " Stride"
+              }`}
             subtitle="A gathering place to address the topics shaping the ATOM Ecosystem"
           >
             {finalData.length > 0 ? (

--- a/src/components/Assets.tsx/AssetSection1.tsx
+++ b/src/components/Assets.tsx/AssetSection1.tsx
@@ -44,7 +44,7 @@ const AssetSection1 = ({
       if (!combinedData[label]) {
         combinedData[label] = { ...item };
       } else {
-        combinedData[label].amount += item.amount;
+        combinedData[label].total_supply += item.total_supply;
       }
     });
 
@@ -67,7 +67,7 @@ const AssetSection1 = ({
     let graphData = option.map((item) => {
       return {
         label: item.name.label,
-        amount: item.amount,
+        amount: item.total_supply,
       };
     });
 
@@ -97,7 +97,7 @@ const AssetSection1 = ({
 
   const calculateTotalAmount = (data: any) => {
     return data.reduce(
-      (total: number, item: assetType) => total + item.amount,
+      (total: number, item: assetType) => total + item.total_supply,
       0
     );
   };

--- a/src/components/DataDisplay/CustomTable.tsx
+++ b/src/components/DataDisplay/CustomTable.tsx
@@ -115,7 +115,7 @@ const CustomTable = ({
                     fontWeight={500}
                     fontFamily={"Alata, sans-serif"}
                   >
-                    {item}{" "}
+                    {item.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}{" "}
                     {(item === "Forum Date" ||
                       ValidatorKeys.includes(item)) && (
                       <FontAwesomeIcon

--- a/src/components/types/types.ts
+++ b/src/components/types/types.ts
@@ -10,5 +10,5 @@ export type assetType = {
 
 export type assetPieType = {
     label: string;
-    amount: number;
+    total_supply: number;
 }

--- a/src/components/types/types.ts
+++ b/src/components/types/types.ts
@@ -1,5 +1,5 @@
 export type assetType = {
-    amount: number,
+    total_supply: number,
     value: number,
     name: {
         label: string,

--- a/src/hooks/chains/cosmos/chain_assets/useCosmosAssets.ts
+++ b/src/hooks/chains/cosmos/chain_assets/useCosmosAssets.ts
@@ -36,7 +36,7 @@ export const useCosmosAssets = () => {
             label: "ATOM",
             url: "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.png",
           },
-          amount: Number(coinConvert(asset.amount, 6, "human")),
+          total_supply: Number(coinConvert(asset.amount, 6, "human")),
           value: Number(coinConvert(asset.amount, 6, "human")) * price,
         },
       ];

--- a/src/hooks/chains/neutron/chain_assets/useNeutronAssets.ts
+++ b/src/hooks/chains/neutron/chain_assets/useNeutronAssets.ts
@@ -42,7 +42,7 @@ export const useNeutronAssets = () => {
               neutronAssetList[token as keyof typeof neutronAssetList]?.symbol,
             url: neutronAssetList[token as keyof typeof neutronAssetList]?.icon,
           },
-          amount: assetBalances.assetBalancesInDenom[asset],
+          total_supply: assetBalances.assetBalancesInDenom[asset],
           value: assetBalances.assetBalances[asset],
         },
       ];

--- a/src/hooks/chains/stride/chain_assets/useStrideAssets.tsx
+++ b/src/hooks/chains/stride/chain_assets/useStrideAssets.tsx
@@ -47,7 +47,7 @@ export const useStrideAssets = () => {
             label: assetData?.name,
             url: assetData.icon,
           },
-          amount: Number(
+          total_supply: Number(
             coinConvert(asset.amount, assetData?.decimals, "human")
           ),
           value:

--- a/src/pages/Assets.tsx
+++ b/src/pages/Assets.tsx
@@ -33,9 +33,11 @@ const Assets = () => {
     if (!neutronAssets.assets.length) getParsedNeutronAssets();
   };
 
+
+
   return (
 
-    <AssetSection1 allAssets={[...neutronAssets.assets, ...cosmosAssets.assets, ...strideAssets.assets]} neutronAssets={neutronAssets.assets} cosmosAssets={cosmosAssets.assets} strideAssets={strideAssets.assets} />
+    <AssetSection1 allAssets={[...neutronAssets.assets, ...cosmosAssets.assets, ...strideAssets.assets]} neutronAssets={neutronAssets.assets} cosmosAssets={cosmosAssets.assets} strideAssets={strideAssets.assets} areAllAssetsLoaded = {(strideAssets.assets.length>0 && cosmosAssets.assets.length>0 && neutronAssets.assets.length>0)?true:false}/>
   );
 };
 

--- a/src/pages/Assets.tsx
+++ b/src/pages/Assets.tsx
@@ -15,9 +15,12 @@ const Assets = () => {
   const { getParsedStrideAssets } = useStrideAssets();
   const { getParsedCosmosAssets } = useCosmosAssets();
   const { getParsedNeutronAssets } = useNeutronAssets();
+
+
   const strideAssets = useRecoilValue(strideAssetState);
   const cosmosAssets = useRecoilValue(cosmosAssetState);
   const neutronAssets = useRecoilValue(neutronAssetState);
+
 
   useEffect(() => {
     getSupply();


### PR DESCRIPTION
- Pie chart and assets table data on all network only appear when all the three network assets have been loaded, so that user does not sees the incorrect data.
- Renamed the "Amount" column to "Total Supply" in Assets Table
- Updated the Table value when switching from All Networks to Neutron and also change the doughnut chart label from initially showing the total supply with dollars to now displaying the value of the asset.